### PR TITLE
修复脚本在读取进程名称时闪退的问题

### DIFF
--- a/utils/util.py
+++ b/utils/util.py
@@ -57,6 +57,7 @@ if PLATFORM:
     def set_top_window(title):
         top_windows = []
         win32gui.EnumWindows(windowEnumerationHandler, top_windows)
+        title = title.lower()
         for i in top_windows:
             if title in i[1].lower():
                 win32gui.ShowWindow(i[0], 5)
@@ -120,9 +121,12 @@ def move2loc(x, y, title='炉石传说'):
 
 def proc_exist(process_names):
     for p in psutil.process_iter():
-        if len(p.name()) > 0 and p.name() in process_names:
-            print(f"find {p.name()} exists")
-            return True
+        try:
+            if len(p.name()) > 0 and p.name() in process_names:
+                print(f"find {p.name()} exists")
+                return True
+        except Exception as e:
+            print(f"can not get name of process {e}")
     return False
 
 


### PR DESCRIPTION
1.修复脚本在读取进程名称时闪退的问题
2.修复英文客户端窗口名称比较时大小写不一致，导致找不到窗口的问题