### PR TITLE
添加opencv相关依赖

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ hslog==1.16.1
 MouseInfo
 numpy
 opencv-python==3.4.1.15
+opencv-contrib-python==3.4.1.15 
 Pillow
 psutil
 PyAutoGUI


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/24662311/143283349-392269b3-9ffc-4758-9e9e-af1afb2bf291.png)
用python 3.6 启动的时候发现执行到扫描地图之后便不能继续执行， 后面发现是少了相关依赖，便上网查询了下  需要添加 `opencv-contrib-python` 包