### PR TITLE
修复boss关卡判断问题，调整默认配置

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -56,6 +56,6 @@ ui_lang: chs
 battle_stratege: normal # 普通关卡战斗策略， normal 就是之前的版本。 max_dmg: 是不考虑自身生存，尽可能输出最大。 kill_min: 先集火低低生命值的敌人； kill_big: 先集火生命值最大的人。
 boss_battle_stratege: kill_big # 打boss 时的攻击策略
 lettuce_role_limit: 2 # 同色敌人规避阈值， 当敌方同色数大于该值时，会调整上场的英雄的顺序，来规避颜色暴击
-stop_at_boss: true # 在攻击boss关卡前停下，等待人工介入boss战斗
+stop_at_boss: false # 在攻击boss关卡前停下，等待人工介入boss战斗
 map_decision: visitor_first # 地区抉择策略： visitor_first - 直指神秘人； fast_pass - 快速通关，优先选战斗非战斗关卡（局部最优）
 

--- a/utils/images.py
+++ b/utils/images.py
@@ -149,17 +149,20 @@ def get_burning_blue_lines(img, minRad = 10, maxRad = 100):
 def get_dark_brown_lines(img, minRad = 10, maxRad = 110):
     hsv = cv2.cvtColor(img, cv2.COLOR_BGR2HSV)
 
-    lower_color = np.array([4, 10, 10]) # 0 - 10, x - x, 10 - 180
+    lower_color = np.array([4, 80, 10]) # 0 - 10, x - x, 10 - 180
     upper_color = np.array([10, 255, 100])
     mask = cv2.inRange(hsv, lower_color, upper_color)
     res = cv2.bitwise_and(img, img, mask=mask)
+    # cv2.imwrite("test_boss_check_1.png", res) 
 
-    lower_color = np.array([150, 10, 10])
+    lower_color = np.array([150, 80, 10])
     upper_color = np.array([180, 255, 100])
     mask2 = cv2.inRange(hsv, lower_color, upper_color)
     res2 = cv2.bitwise_and(img, img, mask=mask2)
+    # cv2.imwrite("test_boss_check_2.png", res2)
 
     dst = cv2.addWeighted(res, 1, res2, 1, 0)   # 图片组合
+    # cv2.imwrite("test_boss_check_3.png", dst)
 
     gay_img = cv2.cvtColor(dst, cv2.COLOR_BGRA2GRAY)
 
@@ -182,6 +185,6 @@ def get_dark_brown_lines(img, minRad = 10, maxRad = 110):
     #     x2 = int(x0 - 1000*(-b))
     #     y2 = int(y0 - 1000*(a))
     #     cv2.line(img,(x1,y1),(x2,y2),(0,0,255),2)
-    # cv2.imwrite("gar_img111.png", img)
+    # cv2.imwrite("test_boss_check_6.png", img)
 
     return lines

--- a/utils/test_images.py
+++ b/utils/test_images.py
@@ -100,7 +100,8 @@ class TestImage(unittest.TestCase):
     def test_get_dark_brown_lines(self):
         # screen = self.get_save_image( to_gray=False, imageName= "battle_boss.png")
         # screen = self.get_save_image( to_gray=False, imageName= "batle_en_1.png")
-        screen = self.get_save_image( to_gray=False, imageName= "restart_04-35.40,455.png") 
+        # screen = self.get_save_image( to_gray=False, imageName= "restart_04-35.40,455.png")
+        screen = self.get_save_image( to_gray=False, imageName= "restart_08-06.57,156.png")  # restart_08-06.57,156.png
         config, locs = self.gen_config()
         print(config, locs.boss_battlefield)
         loc =  locs.boss_battlefield


### PR DESCRIPTION
1. boss关卡是图像特征提取时，阈值配置导致，已修复。
2. 调整默认配置，不勾选 打boss前停下。